### PR TITLE
Create openviz-summit-topic-proposal.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/openviz-summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/openviz-summit-topic-proposal.md
@@ -1,0 +1,113 @@
+---
+name: Open Visualization Collab Summit Session Proposal
+about: Submit a proposal for a session at the Open Visualization Collab Summit 
+title: 'Open Visualization Session Proposal: <Project Name> <Session Title>'
+labels: New York 2023, Collaborator Summit, Session Proposal
+assignees: chrisgervang
+---
+
+### Proposal
+
+<!--
+Thank you! You are submitting a topic for the Open Visualization Collab Summit 2023 in New York City!
+
+Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
+
+Please feel free to link to any other issue, PR, or resource that could be relevant.
+-->
+
+**Topic of the session**
+
+<!--
+Example: "Session space for jQuery Core contributors"
+-->
+
+**Type of the session**
+
+<!--
+Replace the space between the brackets with an x, like [x], to create a checked box.
+-->
+
+- [ ] Collaborate
+- [ ] Workshop
+- [ ] Talk
+
+**Estimated duration of the session**
+
+<!--
+Example: 1 hour / TBD / Open for discussion
+-->
+
+**Date and Time of the session**
+
+<!--
+Share data and time for the session, so that remote attendees can join.
+Example: June 9, 11:00am CDT / TBD / Open for discussion
+-->
+
+**Level**
+
+<!--
+This is the expected level of familiarity with the subject of the session.
+
+Example: If the subject of the session is Node.js, and participants cannot contribute without minimum Intermediate familiarity, the x should go in Intermediate and Advanced.
+
+Note that your choice of Level will signal expectations to your potential participants.
+-->
+
+- [ ] Beginner
+- [ ] Intermediate
+- [ ] Advanced
+
+**Pre-requisite knowledge**
+
+<!--
+List pre-requisite knowledge that it would be required for participants to have or resources you would like them to review before the session. This is different from Level above. Pre-requisite knowledge
+
+Example: It would be helpful for attendees to have some familiarity with the processes of the Release WG, since we plan to do a minor release during the session. That being said, we are happy to walk newer folks through the process. Please review [this doc]() before the session.
+-->
+
+**Describe the session**
+
+<!--
+It's ok to keep this very short, especially if you haven't yet finalized the specifics.
+-->
+
+**Session facilitator(s), Github handle(s) and timezone(s)**
+
+<!--
+Example: Your name (@yourgithubhandle) - CEST, Another name (@anothergithubhandle) - PST.
+
+Here's a handy [guide](https://github.com/nodejs/summit/blob/HEAD/SESSION_FACILITATOR_GUIDE.md) for the person or persons who will facilitate this session.
+-->
+
+**Meeting notes and Virtual Meeting Link**
+
+<!--
+
+Meeting Notes: <ADD YOUR LINK HERE>
+Virtual Meeting link: <ADD YOUR LINK HERE>
+
+-->
+
+**Follow-up / Set-up sessions (if any)**
+
+<!--
+List the sessions that are related. This will help with the sequence of scheduling.
+
+Example: This session depends on the discussions happening in #254.
+-->
+
+**Additional context (optional)**
+
+<!--
+Please let us know if this session is:
+- needs to be led by someone remotely
+- needs to be held at a specific time/date, and if so, which which that is
+-->
+
+----
+
+<!--
+Thank you for the Session Proposal. You're done! The next section is for logistics and planning only.
+-->


### PR DESCRIPTION
Pre a conversation with @chrisgervang, the Open Viz team would like to collect proposals for their upcoming summit in NYC. 

We needed to create a new template because the current one is specific to Bilbao.