### PR TITLE
Remove summit-specific information in the summit topic proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
+++ b/.github/ISSUE_TEMPLATE/summit-topic-proposal.md
@@ -9,7 +9,7 @@ assignees: ovflowd, ruyadorno, mcollina
 ### Proposal
 
 <!--
-Thank you! You are submitting a topic for the next Collaborator's Summit, London (UK) 2024!
+Thank you! You are submitting a topic for the next Collaboration summit!
 
 Please include as much detail as you are able to at this moment. Don't worry, it doesn't have to be complete.
 


### PR DESCRIPTION
So that we don't need to update it for every summit :)